### PR TITLE
Enlightenment Policy Changes - Implemented and Tested

### DIFF
--- a/Data/EnlightenmentPolicyChanges.sql
+++ b/Data/EnlightenmentPolicyChanges.sql
@@ -1,0 +1,29 @@
+
+-- EnlightenmentPolicyChanges.sql
+-- Created using Sublime Text, by Steven A. Warren (ScottishRamblyMan), on 19/11/2016
+-- Related File: EnlightenmentPolicyDescriptionUpdates.xml, Location: Root\Text
+
+/*
+	'The Enlightenment' Civic unlocks 3 Policies:
+		- Rationalism (+100% Science from Campus district buildings)
+		- Free Market (+100% Gold yield from Commercial Hub district buildings)
+		- Liberalism  (+1 Amenity to all cities with at least 2 specialty districts)
+	
+	The changes below increase these bonuses five-fold (to facilitate a faster paced end-game). Additionally,
+	the descriptions of these Policies are updated to reflect the changes. This discription is displayed on hovering, 
+	as well as in the Civilopedia.
+*/
+
+-- Rationalism
+UPDATE ModifierArguments SET Value='500' WHERE ModifierId='RATIONALISM_DOUBLELIBRARY' AND Name='Amount';
+UPDATE ModifierArguments SET Value='500' WHERE ModifierId='RATIONALISM_DOUBLEUNIVERSITY' AND Name='Amount';
+UPDATE ModifierArguments SET Value='500' WHERE ModifierId='RATIONALISM_DOUBLERESEARCHLABS' AND Name='Amount';
+
+-- Free Market
+UPDATE ModifierArguments SET Value='500' WHERE ModifierId='FREEMARKET_DOUBLEMARKET' AND Name='Amount';
+UPDATE ModifierArguments SET Value='500' WHERE ModifierId='FREEMARKET_DOUBLEBANK' AND Name='Amount';
+UPDATE ModifierArguments SET Value='500' WHERE ModifierId='FREEMARKET_DOUBLESTOCKEXCHANGE' AND Name='Amount';
+
+-- Liberalism
+UPDATE ModifierArguments SET Value='5' WHERE ModifierId='LIBERALISM_SPECIALTYAMENITY' AND Name='Amount';
+

--- a/LiquidMod.modinfo
+++ b/LiquidMod.modinfo
@@ -14,6 +14,7 @@
 				<File>Data/AntiCavalryChanges.xml</File>
 				<File>Data/ArcherChanges.xml</File>
 				<File>Data/ChopChanges.xml</File>
+				<File>Data/EnlightenmentPolicyChanges.sql</File>
 				<File>Data/HorsemanChanges.xml</File>
 				<File>Data/ImprovementYieldChanges.xml</File>
 				<File>Data/LowerCivicCost.xml</File>
@@ -25,6 +26,7 @@
 		<LocalizedText id="LIQUID_MOD_TEXT">
 			<Items>
 				<File>Text/AntiCavalryChangesText.xml</File>
+				<File>Text/EnlightenmentPolicyDescriptionUpdates.xml</File>
 				<File>Text/HorsemanChangesText.xml</File>
 				<File>Text/TileImprovementsTextChanges.xml</File>
 			</Items>
@@ -35,6 +37,7 @@
 		<File>Data/AntiCavalryChanges.xml</File>
 		<File>Data/ArcherChanges.xml</File>
 		<File>Data/ChopChanges.xml</File>
+		<File>Data/EnlightenmentPolicyChanges.sql</File>
 		<File>Data/HorsemanChanges.xml</File>
 		<File>Data/ImprovementYieldChanges.xml</File>
 		<File>Data/LowerCivicCost.xml</File>
@@ -43,6 +46,7 @@
 		<File>Data/ScoutChanges.xml</File>
 		<!-- localized text -->
 		<File>Text/AntiCavalryChangesText.xml</File>
+		<File>Text/EnlightenmentPolicyDescriptionUpdates.xml</File>
 		<File>Text/HorsemanChangesText.xml</File>
 		<File>Text/TileImprovementsTextChanges.xml</File>
 	</Files>

--- a/Text/EnlightenmentPolicyDescriptionUpdates.xml
+++ b/Text/EnlightenmentPolicyDescriptionUpdates.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Created using Sublime Text, by Steven A. Warren (ScottishRamblyMan), on 19/11/2016 -->
+<!-- Related File: EnlightenmentPolicyChanges.sql, Location: Root\Data -->
+
+<GameData>
+	<LocalizedText>
+		<Replace Tag="LOC_POLICY_RATIONALISM_DESCRIPTION" Language="en_US">
+			<Text>+500% [ICON_Science] Science from Campus district buildings.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FREE_MARKET_DESCRIPTION" Language="en_US">
+			<Text>+500% [ICON_Gold] Gold yield from Commercial Hub district buildings.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LIBERALISM_DESCRIPTION" Language="en_US">
+			<Text>+5 [ICON_Amenities] Amenities to all cities with at least 2 specialty districts.</Text>
+		</Replace>
+	</LocalizedText>
+</GameData>

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,3 +13,4 @@
 * All Units available from the Medieval Era and on cost 50% less Production
 * All Technologies cost 25% less Science to research
 * Scouts have 15 combat strength (up from 10)
+* Policy Cards unlocked by researching 'The Enlightenment' Civic (Rationalism, Free Market & Liberalism) now give 5 times their respective bonus.


### PR DESCRIPTION
* Policy Cards unlocked by researching 'The Enlightenment' Civic (Rationalism, Free Market & Liberalism) now give 5 times their respective bonus.